### PR TITLE
[FEATURE] Use new imgix api to purge images. Fixes #5

### DIFF
--- a/Classes/Domain/Service/ImagePurgeService.php
+++ b/Classes/Domain/Service/ImagePurgeService.php
@@ -32,7 +32,7 @@ use stdClass;
 
 class ImagePurgeService
 {
-    const IMG_PURGE_REQUEST_URL = 'https://api.imgix.com/v2/image/purger';
+    const IMG_PURGE_REQUEST_URL = 'https://api.imgix.com/api/v1/purge';
 
     /**
      * @var Configuration
@@ -76,7 +76,10 @@ class ImagePurgeService
         }
 
         $postRequest = new stdClass();
-        $postRequest->url = $imageUrl;
+        $postRequest->data = new stdClass();
+        $postRequest->data->attributes = new stdClass();
+        $postRequest->data->attributes->url = $imageUrl;
+        $postRequest->data->type = 'purges';
 
         $result = $this->doPostRequest($postRequest);
         if (false === $result->isSuccessful()) {
@@ -95,11 +98,15 @@ class ImagePurgeService
         $postJsonData = json_encode($postRequest);
         $ch = curl_init();
         curl_setopt($ch, CURLOPT_URL, self::IMG_PURGE_REQUEST_URL);
-        curl_setopt($ch, CURLOPT_USERNAME, $this->configuration->getApiKey());
         curl_setopt($ch, CURLOPT_CUSTOMREQUEST, 'POST');
         curl_setopt($ch, CURLOPT_POSTFIELDS, $postJsonData);
         curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
-        curl_setopt($ch, CURLOPT_HTTPHEADER, ['Content-Type: application/json', 'Content-Length: ' . strlen($postJsonData)]);
+        curl_setopt($ch, CURLOPT_HTTPHEADER, [
+            'Authorization: Bearer '.$this->configuration->getApiKey(),
+            'Content-Type: application/vnd.api+json',
+            'Accept: application/vnd.api+json',
+            'Content-Length: ' . strlen($postJsonData)
+        ]);
         curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, false);
         curl_setopt($ch, CURLOPT_CONNECTTIMEOUT, 10);
         curl_setopt($ch, CURLOPT_TIMEOUT, 30);

--- a/Tests/Unit/Domain/Service/ImagePurgeServiceTest.php
+++ b/Tests/Unit/Domain/Service/ImagePurgeServiceTest.php
@@ -85,7 +85,10 @@ class ImagePurgeServiceTest extends UnitTestCase
     {
         $imageUrl = 'http://congstar.imgix.com/directory/image.png';
         $postRequest = new stdClass();
-        $postRequest->url = $imageUrl;
+        $postRequest->data = new stdClass();
+        $postRequest->data->attributes = new stdClass();
+        $postRequest->data->attributes->url = $imageUrl;
+        $postRequest->data->type = 'purges';
         $result = new ImagePurgeResult();
         $result->markImagePurgeAsFailed('curlError', 28, 503);
 
@@ -103,7 +106,10 @@ class ImagePurgeServiceTest extends UnitTestCase
     {
         $imageUrl = 'http://congstar.imgix.com/directory/image.png';
         $postRequest = new stdClass();
-        $postRequest->url = $imageUrl;
+        $postRequest->data = new stdClass();
+        $postRequest->data->attributes = new stdClass();
+        $postRequest->data->attributes->url = $imageUrl;
+        $postRequest->data->type = 'purges';
         $result = new ImagePurgeResult();
         $result->markImagePurgeAsSuccessful();
 


### PR DESCRIPTION
Switch to new imgix API as described in migration guide: https://docs.imgix.com/setup/legacy-api-migration-guide